### PR TITLE
fix(tonic): avoid missing accept on server

### DIFF
--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -57,7 +57,7 @@ impl Endpoint {
 
         // handshake
         let tag = madsim::rand::random::<u64>();
-        ep.send_raw(1, Box::new(tag))
+        ep.send_raw(0, Box::new(tag))
             .await
             .map_err(Error::from_source)?;
         madsim::time::timeout(Duration::from_secs(1), ep.recv_raw(tag))

--- a/madsim/src/sim/rand.rs
+++ b/madsim/src/sim/rand.rs
@@ -51,6 +51,7 @@ pub struct GlobalRng {
 }
 
 struct Inner {
+    seed: u64,
     rng: SmallRng,
     log: Option<Vec<u8>>,
     check: Option<(Vec<u8>, usize)>,
@@ -68,6 +69,7 @@ impl GlobalRng {
         }
 
         let inner = Inner {
+            seed,
             rng: SeedableRng::seed_from_u64(seed),
             log: None,
             check: None,
@@ -102,6 +104,11 @@ impl GlobalRng {
             }
         }
         ret
+    }
+
+    pub(crate) fn seed(&self) -> u64 {
+        let lock = self.inner.lock().unwrap();
+        lock.seed
     }
 
     pub(crate) fn enable_check(&self, log: Log) {

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -220,6 +220,18 @@ impl Handle {
         context::current(|h| h.clone())
     }
 
+    /// Returns the random seed of the current runtime.
+    ///
+    /// ```
+    /// use madsim::{Config, runtime::Runtime};
+    ///
+    /// let rt = Runtime::with_seed_and_config(2333, Config::default());
+    /// assert_eq!(rt.handle().seed(), 2333);
+    /// ```
+    pub fn seed(&self) -> u64 {
+        self.rand.seed()
+    }
+
     /// Kill a node.
     ///
     /// - All tasks spawned on this node will be killed immediately.


### PR DESCRIPTION
`Endpoint::recv` is not cancellation safe! So selecting 2 recv futures may lose message.