### PR TITLE
fix(tokio): no longer need to add madsim dependency

### DIFF
--- a/madsim-tokio/src/lib.rs
+++ b/madsim-tokio/src/lib.rs
@@ -14,7 +14,11 @@ mod sim {
     #[cfg(feature = "time")]
     pub use madsim::time;
     #[cfg(all(feature = "rt", feature = "macros"))]
-    pub use madsim::{main, test};
+    pub use madsim::{tokio_main as main, tokio_test as test};
+    // for macro use
+    #[cfg(all(feature = "rt", feature = "macros"))]
+    #[doc(hidden)]
+    pub use madsim;
 
     pub mod task {
         #[cfg(tokio_unstable)]

--- a/madsim/src/sim/mod.rs
+++ b/madsim/src/sim/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use self::runtime::context;
 
 #[cfg(feature = "macros")]
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-pub use madsim_macros::{main, test};
+pub use madsim_macros::{main, test, tokio_main, tokio_test};
 
 pub mod collections;
 mod config;


### PR DESCRIPTION
Currently using `#[tokio::main]` still needs an explicit import of the madsim crate. This PR fixes this issue.