### PR TITLE
refactor(net): introduce channel and refactor TCP

### DIFF
--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -35,12 +35,10 @@ spin = "0.9"
 ahash = "0.7"
 async-task = "4"
 async-channel = "1.6"
-async-ringbuffer = "0.5"
 downcast-rs = "1.2"
 libc = "0.2"
 naive-timer = "0.2"
 tokio = { version = "1", features = ["rt"] }
-tokio-util = { version = "0.7", features = ["compat"] }
 toml = "0.5"
 
 [target.'cfg(not(madsim))'.dependencies]

--- a/madsim/src/sim/net/network.rs
+++ b/madsim/src/sim/net/network.rs
@@ -1,3 +1,4 @@
+use super::Payload;
 use crate::{rand::*, task::NodeId};
 use downcast_rs::{impl_downcast, DowncastSync};
 use log::*;
@@ -28,7 +29,7 @@ pub(crate) struct Network {
     clogged_link: HashSet<(NodeId, NodeId)>,
 }
 
-/// Network for a node.
+/// A node in the network.
 #[derive(Default)]
 struct Node {
     /// IP address of the node.
@@ -40,7 +41,10 @@ struct Node {
 }
 
 /// Upper-level protocol should implement its own socket type.
-pub trait Socket: Any + Send + Sync + DowncastSync {}
+pub trait Socket: Any + Send + Sync + DowncastSync {
+    /// Deliver a message from other socket.
+    fn deliver(&self, _addr: SocketAddr, _msg: Payload) {}
+}
 impl_downcast!(sync Socket);
 
 /// Network configurations.

--- a/madsim/src/sim/net/network.rs
+++ b/madsim/src/sim/net/network.rs
@@ -37,7 +37,14 @@ struct Node {
     /// NOTE: now a node can have at most one IP address.
     ip: Option<IpAddr>,
     /// Sockets in the node.
-    sockets: HashMap<u16, (IpAddr, Arc<dyn Socket>)>,
+    sockets: HashMap<(SocketAddr, IpProtocol), Arc<dyn Socket>>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IpProtocol {
+    Tcp,
+    Udp,
 }
 
 /// Upper-level protocol should implement its own socket type.
@@ -172,6 +179,7 @@ impl Network {
         &mut self,
         node_id: NodeId,
         mut addr: SocketAddr,
+        protocol: IpProtocol,
         socket: Arc<dyn Socket>,
     ) -> io::Result<SocketAddr> {
         let origin_addr = addr;
@@ -190,14 +198,18 @@ impl Network {
         // resolve port if unspecified
         if addr.port() == 0 {
             let port = (1..=u16::MAX)
-                .find(|port| !node.sockets.contains_key(port))
+                .find(|&port| {
+                    !node
+                        .sockets
+                        .contains_key(&((addr.ip(), port).into(), protocol))
+                })
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::AddrInUse, "no available ephemeral port")
                 })?;
             addr.set_port(port);
         }
         // insert socket
-        match node.sockets.entry(addr.port()) {
+        match node.sockets.entry((addr, protocol)) {
             Entry::Occupied(_) => {
                 return Err(io::Error::new(
                     io::ErrorKind::AddrInUse,
@@ -205,7 +217,7 @@ impl Network {
                 ))
             }
             Entry::Vacant(o) => {
-                o.insert((addr.ip(), socket));
+                o.insert(socket);
             }
         }
         debug!("bind: {node_id} {origin_addr} -> {addr}");
@@ -213,10 +225,10 @@ impl Network {
     }
 
     /// Close a socket.
-    pub fn close(&mut self, node: NodeId, port: u16) {
-        debug!("close: {node} port={port}");
+    pub fn close(&mut self, node: NodeId, addr: SocketAddr, protocol: IpProtocol) {
+        debug!("close: {node} {addr} {protocol:?}");
         let node = self.nodes.get_mut(&node).expect("node not found");
-        node.sockets.remove(&port);
+        node.sockets.remove(&(addr, protocol));
     }
 
     /// Returns the latency of sending a packet. If packet loss, returns `None`.
@@ -225,15 +237,22 @@ impl Network {
             None
         } else {
             self.stat.msg_count += 1;
+            // TODO: special value for loopback
             Some(self.rand.gen_range(self.config.send_latency.clone()))
         }
     }
 
     /// Resolve destination node from IP address.
-    pub fn resolve_dest_node(&self, node: NodeId, dst: SocketAddr) -> Option<NodeId> {
-        if dst.ip().is_loopback() {
+    pub fn resolve_dest_node(
+        &self,
+        node: NodeId,
+        dst: SocketAddr,
+        protocol: IpProtocol,
+    ) -> Option<NodeId> {
+        let node0 = self.nodes.get(&node).expect("node not found");
+        if dst.ip().is_loopback() || node0.sockets.contains_key(&(dst, protocol)) {
             Some(node)
-        } else if self.nodes.get(&node).expect("node not found").ip.is_none() {
+        } else if node0.ip.is_none() {
             warn!("ip not set: {node}");
             None
         } else if let Some(x) = self.addr_to_node.get(&dst.ip()) {
@@ -252,15 +271,18 @@ impl Network {
         &mut self,
         node: NodeId,
         dst: SocketAddr,
+        protocol: IpProtocol,
     ) -> Option<(IpAddr, Arc<dyn Socket>, Duration)> {
-        let dst_node = self.resolve_dest_node(node, dst)?;
+        let dst_node = self.resolve_dest_node(node, dst, protocol)?;
         let latency = self.test_link(node, dst_node)?;
-        let (bound_ip, ep) = self.nodes.get(&dst_node)?.sockets.get(&dst.port())?;
-        if bound_ip.is_loopback() && node != dst_node {
-            return None;
-        }
-        let src_ip = (self.nodes.get(&node).expect("node not found").ip)
-            .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let sockets = &self.nodes.get(&dst_node)?.sockets;
+        let ep = (sockets.get(&(dst, protocol)))
+            .or_else(|| sockets.get(&((Ipv4Addr::UNSPECIFIED, dst.port()).into(), protocol)))?;
+        let src_ip = if dst.ip().is_loopback() {
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        } else {
+            self.nodes.get(&node).expect("node not found").ip.unwrap()
+        };
         Some((src_ip, ep.clone(), latency))
     }
 }

--- a/madsim/src/sim/net/rpc.rs
+++ b/madsim/src/sim/net/rpc.rs
@@ -61,6 +61,7 @@
 //! ```
 
 use super::*;
+use crate::rand::random;
 #[doc(no_inline)]
 pub use bytes::Bytes;
 use futures::FutureExt;
@@ -117,7 +118,7 @@ impl Endpoint {
         data: &[u8],
     ) -> io::Result<(R::Response, Bytes)> {
         let req_tag = R::ID;
-        let rsp_tag = self.net.rand.with(|rng| rng.gen::<u64>());
+        let rsp_tag = random::<u64>();
         let data = Bytes::copy_from_slice(data);
         self.send_to_raw(dst, req_tag, Box::new((rsp_tag, request, data)))
             .await?;

--- a/madsim/src/sim/net/tcp/stream.rs
+++ b/madsim/src/sim/net/tcp/stream.rs
@@ -1,38 +1,33 @@
-use super::TcpListenerSocket;
 use crate::{
-    net::{lookup_host, network::Socket, IpProtocol::Tcp, NetSim, ToSocketAddrs},
+    net::{lookup_host, network::Socket, BindGuard, IpProtocol::Tcp, NetSim, ToSocketAddrs},
     plugin,
     task::NodeId,
 };
+use bytes::{Buf, Bytes, BytesMut};
 use log::*;
 use std::{
-    fmt,
-    future::Future,
-    io,
+    fmt, io,
     net::SocketAddr,
     pin::Pin,
-    sync::{Arc, Weak},
+    sync::Arc,
     task::{Context, Poll},
-    time::Duration,
 };
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::{mpsc, oneshot},
+};
 
 /// A TCP stream between a local and a remote socket.
 pub struct TcpStream {
-    net: Arc<NetSim>,
-    node: NodeId,
+    pub(super) guard: Option<Arc<BindGuard>>,
     addr: SocketAddr,
     peer: SocketAddr,
     /// Buffer write data to be flushed.
-    write_buf: Vec<u8>,
-    /// Data that can be read.
-    data: async_ringbuffer::Duplex,
-    /// To indicate connection closed.
-    peer_socket: Weak<TcpStreamSocket>,
+    write_buf: BytesMut,
+    read_buf: Bytes,
+    tx: mpsc::UnboundedSender<Bytes>,
+    rx: mpsc::UnboundedReceiver<Bytes>,
 }
-
-// TODO: make sure it is safe
-unsafe impl Send for TcpStream {}
 
 impl fmt::Debug for TcpStream {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -78,53 +73,49 @@ impl TcpStream {
     /// Connects to one address.
     async fn connect1(net: &Arc<NetSim>, node: NodeId, addr: SocketAddr) -> io::Result<TcpStream> {
         trace!("connecting to {}", addr);
-        let (ip, socket, latency) =
-            net.network
-                .lock()
-                .try_send(node, addr, Tcp)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::ConnectionRefused,
-                        "there is no remote listener",
-                    )
-                })?;
-        let listener = socket.downcast_arc::<TcpListenerSocket>().ok().unwrap();
-        // delay for 1.5 RTT handshake
-        net.time.sleep(latency * 3).await;
+        // send a request to listener and wait for TcpStream
+        // FIXME: the port it uses should not be exclusive
+        let guard = BindGuard::bind("0.0.0.0:0", Tcp, Arc::new(TcpStreamSocket)).await?;
+        let (tx, rx) = oneshot::channel::<TcpStream>();
+        net.send(node, guard.addr.port(), addr, Tcp, Box::new((node, tx)))
+            .await?;
+        let mut stream = rx
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, e))?;
+        stream.guard = Some(Arc::new(guard));
+        Ok(stream)
+    }
 
-        // bind sockets
-        let dst_node = net
-            .network
-            .lock()
-            .resolve_dest_node(node, addr, Tcp)
-            .unwrap();
-        let local_socket = Arc::new(TcpStreamSocket);
-        let peer_socket = Arc::new(TcpStreamSocket);
-        let local_addr =
-            (net.network.lock()).bind(node, (ip, 0).into(), Tcp, local_socket.clone())?;
-        let peer_addr =
-            (net.network.lock()).bind(dst_node, (addr.ip(), 0).into(), Tcp, peer_socket.clone())?;
-        let (d1, d2) = async_ringbuffer::Duplex::pair(0x10_0000);
-        let local = TcpStream {
-            net: net.clone(),
-            node,
-            addr: local_addr,
-            peer: peer_addr,
-            write_buf: vec![],
-            data: d1,
-            peer_socket: Arc::downgrade(&peer_socket),
+    /// Creates a pair of [`TcpStream`].
+    pub(super) fn pair(
+        node1: NodeId,
+        node2: NodeId,
+        addr1: SocketAddr,
+        addr2: SocketAddr,
+    ) -> (TcpStream, TcpStream) {
+        trace!("new tcp connection {} <-> {}", addr1, addr2);
+        let net = plugin::simulator::<NetSim>();
+        let (tx1, rx1) = net.channel(node1, addr2);
+        let (tx2, rx2) = net.channel(node2, addr1);
+        let s1 = TcpStream {
+            guard: None,
+            addr: addr1,
+            peer: addr2,
+            write_buf: Default::default(),
+            read_buf: Default::default(),
+            tx: tx1,
+            rx: rx2,
         };
-        let peer = TcpStream {
-            net: net.clone(),
-            node: dst_node,
-            addr: peer_addr,
-            peer: local_addr,
-            write_buf: vec![],
-            data: d2,
-            peer_socket: Arc::downgrade(&local_socket),
+        let s2 = TcpStream {
+            guard: None,
+            addr: addr2,
+            peer: addr1,
+            write_buf: Default::default(),
+            read_buf: Default::default(),
+            tx: tx2,
+            rx: rx1,
         };
-        listener.tx.try_send((peer, local_addr)).unwrap();
-        Ok(local)
+        (s1, s2)
     }
 
     /// Sets the value of the `TCP_NODELAY` option on this socket.
@@ -144,30 +135,30 @@ impl TcpStream {
     }
 }
 
-impl Drop for TcpStream {
-    fn drop(&mut self) {
-        // avoid panic on panicking
-        if let Some(mut network) = self.net.network.try_lock() {
-            network.close(self.node, self.addr, Tcp);
-        }
-    }
-}
-
 impl AsyncRead for TcpStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        use tokio_util::compat::FuturesAsyncReadCompatExt;
-        match Pin::new(&mut (&mut self.data).compat()).poll_read(cx, buf) {
-            Poll::Pending if self.peer_socket.strong_count() == 0 => {
-                // ref: https://man7.org/linux/man-pages/man2/recv.2.html
-                // > When a stream socket peer has performed an orderly shutdown, the
-                // > return value will be 0 (the traditional "end-of-file" return).
-                Poll::Ready(Ok(()))
+        // read the buffer if not empty
+        if !self.read_buf.is_empty() {
+            let len = self.read_buf.len().min(buf.remaining());
+            buf.put_slice(&self.read_buf[..len]);
+            self.read_buf.advance(len);
+            return Poll::Ready(Ok(()));
+        }
+        // otherwise wait on channel
+        match self.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(data)) => {
+                self.read_buf = data;
+                self.poll_read(cx, buf)
             }
-            x => x,
+            // ref: https://man7.org/linux/man-pages/man2/recv.2.html
+            // > When a stream socket peer has performed an orderly shutdown, the
+            // > return value will be 0 (the traditional "end-of-file" return).
+            Poll::Ready(None) => Poll::Ready(Ok(())),
         }
     }
 }
@@ -183,29 +174,12 @@ impl AsyncWrite for TcpStream {
         Poll::Ready(Ok(buf.len()))
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // connection reset?
-        if self.peer_socket.strong_count() == 0 {
-            return Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "connection closed",
-            )));
-        }
-        // wait until link is available
-        if (self.net.network.lock())
-            .try_send(self.node, self.peer, Tcp)
-            .is_none()
-        {
-            let mut sleep = self.net.time.sleep(Duration::from_secs(1));
-            futures::ready!(Pin::new(&mut sleep).poll(cx));
-        }
+    fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         // send data
-        let this = self.get_mut();
-        use tokio_util::compat::FuturesAsyncWriteCompatExt;
-        let len = futures::ready!(
-            Pin::new(&mut (&mut this.data).compat_write()).poll_write(cx, &this.write_buf)
-        )?;
-        this.write_buf.drain(..len);
+        let data = self.write_buf.split().freeze();
+        self.tx
+            .send(data)
+            .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e))?;
         Poll::Ready(Ok(()))
     }
 

--- a/madsim/src/sim/plugin.rs
+++ b/madsim/src/sim/plugin.rs
@@ -7,7 +7,12 @@ use std::{
 
 use downcast_rs::{impl_downcast, DowncastSync};
 
-use crate::{rand::GlobalRng, task::NodeId, time::TimeHandle, Config};
+use crate::{
+    rand::GlobalRng,
+    task::{NodeId, TaskNodeHandle},
+    time::TimeHandle,
+    Config,
+};
 
 /// Simulator
 pub trait Simulator: Any + Send + Sync + DowncastSync {
@@ -17,6 +22,15 @@ pub trait Simulator: Any + Send + Sync + DowncastSync {
     fn new(rand: &GlobalRng, time: &TimeHandle, config: &Config) -> Self
     where
         Self: Sized;
+
+    // XXX: For compatibility. Merge to `new` in the next major version.
+    #[doc(hidden)]
+    fn new1(rand: &GlobalRng, time: &TimeHandle, _task: &TaskNodeHandle, config: &Config) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new(rand, time, config)
+    }
 
     /// Create a node.
     fn create_node(&self, _id: NodeId) {}

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -66,9 +66,10 @@ impl Runtime {
     /// Register a simulator.
     pub fn add_simulator<S: plugin::Simulator>(&self) {
         let mut sims = self.handle.sims.lock();
-        let sim = Arc::new(S::new(
+        let sim = Arc::new(S::new1(
             &self.handle.rand,
             &self.handle.time,
+            &self.handle.task.get_node(NodeId::zero()).unwrap(),
             &self.handle.config,
         ));
         // create node for supervisor

--- a/madsim/src/sim/time/mod.rs
+++ b/madsim/src/sim/time/mod.rs
@@ -133,13 +133,17 @@ impl TimeHandle {
         }
     }
 
-    pub(crate) fn add_timer(
+    pub(crate) fn add_timer_at(
         &self,
         deadline: Instant,
         callback: impl FnOnce() + Send + Sync + 'static,
     ) {
         let mut timer = self.timer.lock();
         timer.add(deadline - self.clock.base_instant(), |_| callback());
+    }
+
+    pub(crate) fn add_timer(&self, dur: Duration, callback: impl FnOnce() + Send + Sync + 'static) {
+        self.add_timer_at(self.clock.now_instant() + dur, callback);
     }
 }
 

--- a/madsim/src/sim/time/sleep.rs
+++ b/madsim/src/sim/time/sleep.rs
@@ -49,7 +49,7 @@ impl Future for Sleep {
             return Poll::Ready(());
         }
         let waker = cx.waker().clone();
-        self.handle.add_timer(self.deadline, || waker.wake());
+        self.handle.add_timer_at(self.deadline, || waker.wake());
         Poll::Pending
     }
 }

--- a/tonic-example/src/client.rs
+++ b/tonic-example/src/client.rs
@@ -28,8 +28,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     let response = client.lots_of_replies(request).await?;
     let mut stream = response.into_inner();
-    while let Some(reply) = stream.message().await? {
-        println!("{:?}", reply);
+    loop {
+        match stream.message().await {
+            Ok(Some(reply)) => println!("{:?}", reply),
+            Ok(None) => break,
+            Err(e) => {
+                println!("Error: {:?}", e);
+                break;
+            }
+        }
     }
     println!();
 


### PR DESCRIPTION
- add `deliver` method to `Socket` trait. let `NetSim` take care of message delivery
- introduce `BindGuard` to auto release a bound port on drop
- introduce channel as a reliable and ordered transport over the network
- refactor TCP implementation using channel

Seems that the new Rust toolchain introduced several clippy rules which generate warnings in `prost` crate. We'll ignore the failure of clippy task.
